### PR TITLE
Add player middleware and robust IDs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,15 +1,22 @@
 # app/main.py
 from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse, RedirectResponse, Response, PlainTextResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 import json
 
 from app.routes import game
 from app.routes import market
-from app.utils import genome_fingerprint, canonical_genome
+from app.utils import (
+    genome_fingerprint,
+    canonical_genome,
+    uid,
+    grant_starter_pack,
+)
+from app.db import get_conn, exec1, q, init_db
 
 app = FastAPI()
+init_db()
 templates = Jinja2Templates(directory="app/templates")
 
 # expose a Jinja filter for genome fingerprint in templates
@@ -32,6 +39,28 @@ app.mount("/static", StaticFiles(directory="app/static"), name="static")
 app.include_router(game.router)
 market.ensure_market_schema()
 app.include_router(market.router)
+
+
+@app.middleware("http")
+async def attach_player(request: Request, call_next):
+    """Ensure each request has a persistent player id via cookie."""
+    player_id = request.cookies.get("player_id")
+    conn = get_conn()
+    if not player_id:
+        player_id = uid("player")
+        exec1(conn, "INSERT INTO users(id) VALUES(?)", (player_id,))
+        grant_starter_pack(conn, player_id)
+    else:
+        rows = q(conn, "SELECT id FROM users WHERE id=?", (player_id,))
+        if not rows:
+            exec1(conn, "INSERT INTO users(id) VALUES(?)", (player_id,))
+            grant_starter_pack(conn, player_id)
+    conn.close()
+    request.state.player_id = player_id
+    response = await call_next(request)
+    if request.cookies.get("player_id") != player_id:
+        response.set_cookie("player_id", player_id, max_age=60 * 60 * 24 * 365)
+    return response
 
 @app.get("/health")
 def health() -> dict[str, str]:

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,6 +4,7 @@ import hashlib
 import random
 import sqlite3
 import time
+import uuid
 from pathlib import Path
 from typing import Any, Dict, Iterable, Tuple, List
 
@@ -56,11 +57,8 @@ def now_iso() -> str:
 
 
 def uid(prefix: str | None = None) -> str:
-    """
-    Short unique id. If prefix is given, returns <prefix>_<id>.
-    Uses time (ms) + random nibble for low collision chance.
-    """
-    base = f"{int(time.time() * 1000):x}{random.randrange(0, 16):x}"[-8:]
+    """Return a short unique id with optional prefix."""
+    base = uuid.uuid4().hex[:8]
     return f"{prefix}_{base}" if prefix else base
 
 


### PR DESCRIPTION
## Summary
- initialize database on startup
- ensure requests have a player cookie and grant starter seeds
- generate unique ids with uuid to avoid slot collisions

## Testing
- `python -m pytest`
- `uvicorn app.main:app --port 5000 --host 0.0.0.0` then `curl http://localhost:5000/greenhouse | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689a1697bfa0832e9dd6a34e7430f24d